### PR TITLE
chore: migrate standards check to shared action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,23 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Conform audit
-        run: npx @standards-kit/conform audit
-
-      - name: Conform check
-        run: npx @standards-kit/conform check
+      - uses: chrismlittle123/github-actions/typescript-standards-check@main
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

- Replaces inline `npx @standards-kit/conform audit` + `check` steps with the shared `chrismlittle123/github-actions/typescript-standards-check@main` action
- Removes redundant pnpm/node setup steps (handled by the shared action)

Part of chrismlittle123/github-actions#6

## Test plan

- [ ] CI standards job passes on this PR
- [ ] Conform audit and check still run correctly via the shared action

🤖 Generated with [Claude Code](https://claude.com/claude-code)